### PR TITLE
Chore: Add npm build workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,50 @@
+name: Node.js CI and Release
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  release:
+    types: [published]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test
+
+  publish:
+    # 只在 release 事件且发布成功时运行
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: test-and-build  # 依赖于测试构建任务
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        registry-url: 'https://registry.npmjs.org'
+    
+    - run: npm ci
+    - run: npm run build --if-present
+    
+    # 发布到 npm
+    - name: Publish to npm
+      run: npm publish --workspace koishi-plugin-ba-plugin --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,21 +23,47 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
     
     - name: Install dependencies
-      run: npm ci || npm install
+      run: npm install
     
-    - name: Build (optional)
-      run: npm run build --if-present
+    - name: Check for lock file
+      run: |
+        if [ -f package-lock.json ]; then
+          echo "Found package-lock.json, caching dependencies"
+        else
+          echo "No lock file found, using regular install"
+        fi
     
-    # 如果 package.json 中没有 test 脚本，就跳过测试
+    - name: Check package.json scripts
+      run: npm run || echo "No npm scripts defined"
+    
+    # 构建 TypeScript 项目（如果有 tsconfig.json）
+    - name: Check for TypeScript
+      run: |
+        if [ -f tsconfig.json ]; then
+          echo "TypeScript project detected"
+          npx tsc --version || npm install typescript --no-save
+        else
+          echo "No TypeScript config found"
+        fi
+    
+    # 尝试构建，如果有 tsconfig.json 则使用 tsc
+    - name: Build
+      run: |
+        if [ -f tsconfig.json ]; then
+          npx tsc || npm run build --if-present
+        else
+          npm run build --if-present
+        fi
+    
+    # 如果有 test 脚本则运行测试
     - name: Test (if exists)
       run: |
-        if grep -q '"test"' package.json; then
+        if [ -f package.json ] && grep -q '"test"' package.json; then
           npm test
         else
-          echo "No test script found in package.json, skipping tests"
+          echo "No test script found, skipping tests"
         fi
 
   publish:
@@ -55,12 +81,35 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     
     - name: Install dependencies
-      run: npm ci || npm install
+      run: npm install
     
-    - name: Build (optional)
-      run: npm run build --if-present
+    # 构建步骤
+    - name: Build
+      run: |
+        if [ -f tsconfig.json ]; then
+          # 如果使用 TypeScript，先确保安装了 typescript
+          npx tsc --version 2>/dev/null || npm install typescript --no-save
+          npx tsc
+        else
+          npm run build --if-present
+        fi
     
-    # 直接在当前目录发布（假设这就是 koishi-plugin-ba-plugin 包）
+    # 准备发布 - 确保 dist 和 lib 目录存在
+    - name: Prepare for publish
+      run: |
+        echo "Checking build output..."
+        ls -la
+        
+        # 如果 lib 目录不存在但 tsconfig.json 存在，尝试构建
+        if [ ! -d "lib" ] && [ -f tsconfig.json ]; then
+          echo "lib directory not found, building with tsc..."
+          npx tsc --version 2>/dev/null || npm install typescript --no-save
+          npx tsc
+        fi
+        
+        echo "Final structure:"
+        ls -la
+    
     - name: Publish to npm
       run: npm publish --access public
       env:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,34 +17,60 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    
+    - name: Check for lock files
+      run: |
+        echo "Looking for lock files..."
+        find . -name "package-lock.json" -o -name "yarn.lock" -o -name "pnpm-lock.yaml" || echo "No lock files found"
+    
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+    
+    # 根据实际情况调整路径
+    - name: Install dependencies in workspace
+      run: |
+        cd koishi-plugin-ba-plugin || true
+        npm install
+    
+    - name: Build
+      run: |
+        cd koishi-plugin-ba-plugin || true
+        npm run build --if-present
+    
+    - name: Test
+      run: |
+        cd koishi-plugin-ba-plugin || true
+        npm test
 
   publish:
-    # 只在 release 事件且发布成功时运行
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: test-and-build  # 依赖于测试构建任务
+    needs: test-and-build
     runs-on: ubuntu-latest
     
     steps:
     - uses: actions/checkout@v4
+    
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
     
-    - run: npm ci
-    - run: npm run build --if-present
+    - name: Install dependencies in workspace
+      run: |
+        cd koishi-plugin-ba-plugin || true
+        npm install
     
-    # 发布到 npm
+    - name: Build
+      run: |
+        cd koishi-plugin-ba-plugin || true
+        npm run build --if-present
+    
     - name: Publish to npm
-      run: npm publish --workspace koishi-plugin-ba-plugin --access public
+      run: |
+        cd koishi-plugin-ba-plugin
+        npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,8 +9,9 @@ on:
     types: [published]
 
 jobs:
-  test-and-build:
+  build:
     runs-on: ubuntu-latest
+    
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
@@ -18,35 +19,30 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Check for lock files
-      run: |
-        echo "Looking for lock files..."
-        find . -name "package-lock.json" -o -name "yarn.lock" -o -name "pnpm-lock.yaml" || echo "No lock files found"
-    
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     
-    # 根据实际情况调整路径
-    - name: Install dependencies in workspace
-      run: |
-        cd koishi-plugin-ba-plugin || true
-        npm install
+    - name: Install dependencies
+      run: npm ci || npm install
     
-    - name: Build
-      run: |
-        cd koishi-plugin-ba-plugin || true
-        npm run build --if-present
+    - name: Build (optional)
+      run: npm run build --if-present
     
-    - name: Test
+    # 如果 package.json 中没有 test 脚本，就跳过测试
+    - name: Test (if exists)
       run: |
-        cd koishi-plugin-ba-plugin || true
-        npm test
+        if grep -q '"test"' package.json; then
+          npm test
+        else
+          echo "No test script found in package.json, skipping tests"
+        fi
 
   publish:
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: test-and-build
+    needs: build
     runs-on: ubuntu-latest
     
     steps:
@@ -58,19 +54,14 @@ jobs:
         node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
     
-    - name: Install dependencies in workspace
-      run: |
-        cd koishi-plugin-ba-plugin || true
-        npm install
+    - name: Install dependencies
+      run: npm ci || npm install
     
-    - name: Build
-      run: |
-        cd koishi-plugin-ba-plugin || true
-        npm run build --if-present
+    - name: Build (optional)
+      run: npm run build --if-present
     
+    # 直接在当前目录发布（假设这就是 koishi-plugin-ba-plugin 包）
     - name: Publish to npm
-      run: |
-        cd koishi-plugin-ba-plugin
-        npm publish --access public
+      run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
（不想写英文了AwA）

在main分支提交代码后自动运行构建（用来检测可用性AwA）

发布release时自动分发npm包

需要做的准备
- 在 [npmjs.com](https://npmjs.com/) 上生成 token（需要有发布权限）
- 前往仓库 Settings → Secrets and variables → Actions 中添加`NPM_TOKEN`